### PR TITLE
Update events-manager-osm.js

### DIFF
--- a/events-manager-osm.js
+++ b/events-manager-osm.js
@@ -47,4 +47,4 @@ function replaceMap(e, map) {
     map.controls[google.maps.ControlPosition.BOTTOM_RIGHT].push(copyright);
 }
 
-jQuery(document).bind('em_maps_location_hook', replaceMap);
+jQuery(document).on('em_maps_location_hook', replaceMap);


### PR DESCRIPTION
This plugin simply didn't work because jQuery.bind() is deprecated by .on(). The plugin now works in display mode (except that there is still an alert to dismiss), but not in edition mode (maybe this was the case originally too).